### PR TITLE
State api Updates

### DIFF
--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -1,10 +1,9 @@
 package state
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // NewStateManager creates a state.Manager for the given CRD Kind

--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -1,18 +1,13 @@
 package state
 
 import (
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewStateManager creates a state.Manager for the given CRD Kind
-func NewManager(crdKind string, k8sAPIClient client.Client) Manager {
-	// TODO: Implement
-	return &fakeMananger{states: newStates(crdKind, k8sAPIClient)}
-}
-
-// newStates creates States that compose a State manager
-// nolint:unparam
-func newStates(crdKind string, k8sAPIClient client.Client) [][]State {
-	// TODO: Implement
-	return [][]State{{&fakeState{client: k8sAPIClient}}}
+func NewManager(crdKind string, k8sAPIClient client.Client, scheme *runtime.Scheme) (Manager, error) {
+	return &fakeMananger{watchResources: []*source.Kind{}}, nil
 }

--- a/pkg/state/fake_manager.go
+++ b/pkg/state/fake_manager.go
@@ -1,21 +1,23 @@
 package state
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// nolint:unused
 type fakeMananger struct {
-	states         [][]State
-	watchResources []source.Kind
+	watchResources []*source.Kind
 }
 
 // GetWatchSources gets Resources that should be watched by a Controller for this state manager
-func (m *fakeMananger) GetWatchSources() []source.Kind {
+func (m *fakeMananger) GetWatchSources() []*source.Kind {
 	return m.watchResources
 }
 
 // SyncState reconciles the state of the system for the custom resource
-func (m *fakeMananger) SyncState(request *reconcile.Request) (reconcile.Result, error) {
-	return reconcile.Result{}, nil
+func (m *fakeMananger) SyncState(customResource interface{}, serviceCatalog ServiceCatalog) (Results, error) {
+	return Results{
+		Status:       SyncStateNotReady,
+		StatesStatus: nil,
+	}, nil
 }

--- a/pkg/state/fake_state.go
+++ b/pkg/state/fake_state.go
@@ -1,14 +1,13 @@
 package state
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+//nolint:unused
 type fakeState struct {
-	client            client.Client
 	name, description string
-	watchResources    map[string]source.Kind
+	watchResources    map[string]*source.Kind
 }
 
 // Name provides the State name
@@ -23,11 +22,11 @@ func (s *fakeState) Description() string {
 
 // Sync attempt to get the system to match the desired state which State represent.
 // a sync operation must be relatively short and must not block the execution thread.
-func (s *fakeState) Sync() (SyncState, error) {
+func (s *fakeState) Sync(customResource interface{}, serviceCatalog ServiceCatalog) (SyncState, error) {
 	return SyncStateReady, nil
 }
 
 // Get a map of source kinds that should be watched for the state keyed by the source kind name
-func (s *fakeState) GetWatchSources() map[string]source.Kind {
+func (s *fakeState) GetWatchSources() map[string]*source.Kind {
 	return s.watchResources
 }

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -9,7 +8,24 @@ import (
 // A state manager invokes states in order to get the system to its desired state
 type Manager interface {
 	// GetWatchSources gets Resources that should be watched by a Controller for this state manager
-	GetWatchSources() []source.Kind
-	// SyncState reconciles the state of the system and updates status for the custom resource
-	SyncState(request *reconcile.Request) (reconcile.Result, error)
+	GetWatchSources() []*source.Kind
+	// SyncState reconciles the state of the system and returns a list of status of the applied states
+	// ServiceCatalog is provided to optionally provide a State additional services required for it to perform
+	// the Sync operation.
+	SyncState(customResource interface{}, serviceCatalog ServiceCatalog) (Results, error)
+}
+
+// Represent a Result of a single State.Sync() invocation
+type Result struct {
+	StateName string
+	Status    SyncState
+	// if SyncStateError then ErrInfo will contain additional error information
+	ErrInfo error
+}
+
+// Represent the Results of a collection of State.Sync() invocations, Status reflects the global status of all states.
+// If all are SyncStateReady then Status is SyncStateReady, if one is SyncStateNotReady, Status is SyncStateNotReady
+type Results struct {
+	Status       SyncState
+	StatesStatus []Result
 }

--- a/pkg/state/service.go
+++ b/pkg/state/service.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"reflect"
+
+	"github.com/Mellanox/mellanox-network-operator/pkg/nodeinfo"
+)
+
+type ServiceType uint
+
+const (
+	ServiceTypeNodeInfo = iota
+)
+
+func NewServiceCatalog() ServiceCatalog {
+	return &serviceCatalog{services: make(map[ServiceType]interface{})}
+}
+
+// ServiceCatalog is a service catalog to be used to retrieve services. used for State implementation that require
+// additional helping functionality to perfrom the Sync operation. As more States are added,
+// more services may be added to aid them. for any service if not present in the catalog, nil will be returned.
+type ServiceCatalog interface {
+	// Add a service of ServiceType to the catalog, the service added MUST be of pointer type.
+	Add(ServiceType, interface{})
+	// GetNodeInfoProvider returns a reference nodeinfo.Provider from catalog or nil if provider does not exist
+	GetNodeInfoProvider() nodeinfo.Provider
+}
+
+type serviceCatalog struct {
+	services map[ServiceType]interface{}
+}
+
+func (sc *serviceCatalog) Add(st ServiceType, service interface{}) {
+	if reflect.ValueOf(service).Kind() != reflect.Ptr {
+		// We should not get here
+		panic("Invalid interface provided to ServiceCatalog.Add()")
+	}
+	sc.services[st] = service
+}
+
+func (sc *serviceCatalog) GetNodeInfoProvider() nodeinfo.Provider {
+	service, ok := sc.services[ServiceTypeNodeInfo]
+	if !ok {
+		return nil
+	}
+	return service.(nodeinfo.Provider)
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -6,11 +6,13 @@ import (
 
 type SyncState string
 
+// Represents the Sync state of a specific State or a collection of States
 const (
-	SyncStateReady    = "Ready"
-	SyncStateNotReady = "NotReady"
-	SyncStateReset    = "Reset"
-	SyncStateError    = "Error"
+	SyncStateReady    = "ready"
+	SyncStateNotReady = "notReady"
+	SyncStateIgnore   = "ignore"
+	SyncStateReset    = "reset"
+	SyncStateError    = "error"
 )
 
 // State Represents a single State that requires a set of k8s API operations to be performed.
@@ -21,9 +23,12 @@ type State interface {
 	Name() string
 	// Description provides the State description
 	Description() string
-	// Sync attempt to get the system to match the desired state which State represent.
+	// Sync attempt to get the system to match the desired state as depicted in the custom resource
+	// for the bits related to the specific state, State represents.
 	// a sync operation must be relatively short and must not block the execution thread.
-	Sync() (SyncState, error)
+	// ServiceCatalog is provided to optionally provide a State additional services required for it to perform
+	// the Sync operation.
+	Sync(customResource interface{}, serviceCatalog ServiceCatalog) (SyncState, error)
 	// Get a map of source kinds that should be watched for the state keyed by the source kind name
-	GetWatchSources() map[string]source.Kind
+	GetWatchSources() map[string]*source.Kind
 }


### PR DESCRIPTION
This PR Updates the API State and Manager state package components

Changes are needed to decouple:
1. State manager from any awareness of the type of CRD it reconciles and the states it is comprised of
2. State manager from any k8s controller objects (reconcile.Request/Result)
2. a State implementation from the need to be aware of k8s client by introducing a serviceCatalog abstraction