### PR TITLE
mount /etc/network to pod

### DIFF
--- a/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
+++ b/manifests/stage-ofed-driver/0010_ofed-driver-ds.yaml
@@ -37,10 +37,16 @@ spec:
             - name: run-mlnx-ofed
               mountPath: /run/mellanox/drivers
               mountPropagation: Bidirectional
+            - name: etc-network
+              mountPath: /etc/network
       volumes:
         - name: run-mlnx-ofed
           hostPath:
             path: /run/mellanox/drivers
+        - name: etc-network
+          hostPath:
+            path: /etc/network
       nodeSelector:
         feature.node.kubernetes.io/pci-15b3.present: "true"
         feature.node.kubernetes.io/kernel-version.full: {{ .RuntimeSpec.KernelVerFull }}
+


### PR DESCRIPTION
This will allow mlnx_interface_mgr.sh to process
network interfaces after driver load in order to
apply any pre-configured network configurations on them